### PR TITLE
Add AI meme description suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ CLOUDFRONT_DOMAIN=
 # Supabase (always required for auth + database)
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# OpenAI (server-side only)
+OPENAI_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "drizzle-orm": "^0.45.1",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
+        "openai": "^6.37.0",
         "postgres": "^3.4.8",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
@@ -13395,6 +13396,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+      "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
+    "openai": "^6.37.0",
     "postgres": "^3.4.8",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",

--- a/src/app/api/memes/suggest-description/route.test.ts
+++ b/src/app/api/memes/suggest-description/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockGetAuthenticatedUser = vi.fn();
+const mockSuggestMemeDescription = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: () => mockGetAuthenticatedUser(),
+}));
+
+vi.mock("@/lib/ai-description", () => ({
+  suggestMemeDescription: (...args: unknown[]) => mockSuggestMemeDescription(...args),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(formData: FormData) {
+  return {
+    formData: async () => formData,
+  } as NextRequest;
+}
+
+function makeFile(name: string, sizeBytes: number, type: string) {
+  return new File([new ArrayBuffer(sizeBytes)], name, { type });
+}
+
+function authSuccess() {
+  mockGetAuthenticatedUser.mockResolvedValue({
+    dbUser: { id: "user-uuid" },
+    error: null,
+  });
+}
+
+function authFailure(status: number, message: string) {
+  mockGetAuthenticatedUser.mockResolvedValue({
+    dbUser: null,
+    error: NextResponse.json({ error: message }, { status }),
+  });
+}
+
+describe("POST /api/memes/suggest-description", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns 401 when unauthenticated", async () => {
+    authFailure(401, "Unauthorized");
+    const formData = new FormData();
+    formData.append("image", makeFile("meme.png", 1024, "image/png"));
+
+    const res = await POST(makeRequest(formData));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(mockSuggestMemeDescription).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when image is missing", async () => {
+    authSuccess();
+
+    const res = await POST(makeRequest(new FormData()));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing image file" });
+  });
+
+  test("returns 400 for invalid file type", async () => {
+    authSuccess();
+    const formData = new FormData();
+    formData.append("image", makeFile("meme.txt", 1024, "text/plain"));
+
+    const res = await POST(makeRequest(formData));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid file type. Use PNG, JPEG, GIF, or WebP" });
+  });
+
+  test("returns 400 when file exceeds size limit", async () => {
+    authSuccess();
+    const formData = new FormData();
+    formData.append("image", makeFile("meme.png", 2 * 1024 * 1024 + 1, "image/png"));
+
+    const res = await POST(makeRequest(formData));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "File exceeds 2 MB limit" });
+  });
+
+  test("returns suggested description for a valid image", async () => {
+    authSuccess();
+    mockSuggestMemeDescription.mockResolvedValue("A cat looks shocked at a laptop screen.");
+    const formData = new FormData();
+    formData.append("image", makeFile("meme.png", 1024, "image/png"));
+
+    const res = await POST(makeRequest(formData));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      description: "A cat looks shocked at a laptop screen.",
+    });
+    expect(mockSuggestMemeDescription).toHaveBeenCalledWith(expect.any(File));
+  });
+
+  test("returns 502 when AI suggestion fails", async () => {
+    authSuccess();
+    mockSuggestMemeDescription.mockRejectedValue(new Error("OpenAI failed"));
+    const formData = new FormData();
+    formData.append("image", makeFile("meme.png", 1024, "image/png"));
+
+    const res = await POST(makeRequest(formData));
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Failed to suggest description" });
+  });
+});

--- a/src/app/api/memes/suggest-description/route.ts
+++ b/src/app/api/memes/suggest-description/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+import { getAuthenticatedUser } from "@/lib/auth";
+import { ACCEPTED_MIME_TYPES, MAX_FILE_SIZE } from "@/lib/constants";
+import { suggestMemeDescription } from "@/lib/ai-description";
+import { apiError, apiSuccess, type SuggestDescriptionResponse } from "@/lib/validations";
+
+export async function POST(request: NextRequest) {
+  const { error } = await getAuthenticatedUser();
+  if (error) return error;
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return apiError("Invalid form data", 400);
+  }
+
+  const image = formData.get("image");
+  if (!(image instanceof File)) {
+    return apiError("Missing image file", 400);
+  }
+
+  if (!Object.keys(ACCEPTED_MIME_TYPES).includes(image.type)) {
+    return apiError("Invalid file type. Use PNG, JPEG, GIF, or WebP", 400);
+  }
+
+  if (image.size > MAX_FILE_SIZE) {
+    return apiError("File exceeds 2 MB limit", 400);
+  }
+
+  try {
+    const description = await suggestMemeDescription(image);
+    return apiSuccess<SuggestDescriptionResponse>({ description });
+  } catch {
+    return apiError("Failed to suggest description", 502);
+  }
+}

--- a/src/components/upload-form.test.tsx
+++ b/src/components/upload-form.test.tsx
@@ -56,6 +56,9 @@ function mockFetchDefaults() {
       }),
     )
     .on("s3.amazonaws.com", () => new Response(null, { status: 200 }))
+    .on("/api/memes/suggest-description", () =>
+      Response.json({ description: "A cat stares dramatically at a computer screen." }),
+    )
     .on("/api/memes", () => Response.json({ meme: { id: "1", imageUrl: "https://cdn.example.com/user/abc.png" } }));
 }
 
@@ -110,6 +113,7 @@ describe("UploadForm", () => {
 
     expect(screen.getByAltText("Upload preview")).toBeInTheDocument();
     expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /suggest description/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/tags/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /upload/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
@@ -188,6 +192,72 @@ describe("UploadForm", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /upload/i })).toBeEnabled();
+    });
+  });
+
+  test("suggests a description for the selected image", async () => {
+    const user = userEvent.setup();
+    mockFetchDefaults().on("/api/memes/suggest-description", () =>
+      Response.json({ description: "A cat stares dramatically at a computer screen." }),
+    );
+
+    renderWithQueryClient(<UploadForm />);
+
+    await selectFileAndWaitForForm(user);
+    await user.click(screen.getByRole("button", { name: /suggest description/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/description/i)).toHaveValue(
+        "A cat stares dramatically at a computer screen.",
+      );
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/memes/suggest-description",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(FormData),
+      }),
+    );
+  });
+
+  test("disables description suggestion after success until a new image is selected", async () => {
+    const user = userEvent.setup();
+    mockFetchDefaults();
+
+    renderWithQueryClient(<UploadForm />);
+
+    await selectFileAndWaitForForm(user);
+    await user.click(screen.getByRole("button", { name: /suggest description/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/description/i)).toHaveValue(
+        "A cat stares dramatically at a computer screen.",
+      );
+      expect(screen.getByRole("button", { name: /suggest description/i })).toBeDisabled();
+      expect(screen.getByText("Description suggested")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await selectFileAndWaitForForm(user);
+
+    expect(screen.getByRole("button", { name: /suggest description/i })).toBeEnabled();
+  });
+
+  test("shows toast when description suggestion fails", async () => {
+    const user = userEvent.setup();
+    mockFetchDefaults().on(
+      "/api/memes/suggest-description",
+      Response.json({ error: "Failed to suggest description" }, { status: 502 }),
+    );
+
+    renderWithQueryClient(<UploadForm />);
+
+    await selectFileAndWaitForForm(user);
+    await user.click(screen.getByRole("button", { name: /suggest description/i }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Failed to suggest description");
     });
   });
 

--- a/src/components/upload-form.tsx
+++ b/src/components/upload-form.tsx
@@ -10,11 +10,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { TagInput } from "@/components/tag-input";
-import { Upload, X, CheckCircle, AlertCircle, Loader2 } from "lucide-react";
+import { Upload, X, CheckCircle, AlertCircle, Loader2, Sparkles } from "lucide-react";
 import { SUCCESS_DISPLAY_MS } from "@/lib/constants";
 import { MAX_FILE_SIZE, ACCEPTED_MIME_TYPES } from "@/lib/constants";
 import { createMemeSchema } from "@/lib/validations";
-import type { TagListResponse } from "@/lib/validations";
+import type { SuggestDescriptionResponse, TagListResponse } from "@/lib/validations";
 import { invalidateAll } from "@/lib/optimistic-cache";
 import { apiFetch } from "@/lib/api-fetch";
 
@@ -36,6 +36,8 @@ export function UploadForm() {
   const [uploadState, setUploadState] = useState<UploadState>({
     status: "idle",
   });
+  const [isSuggestingDescription, setIsSuggestingDescription] = useState(false);
+  const [hasSuggestedDescription, setHasSuggestedDescription] = useState(false);
 
   const tagsQuery = useQuery({
     queryKey: ["tags"],
@@ -51,6 +53,7 @@ export function UploadForm() {
     register,
     handleSubmit,
     control,
+    setValue,
     reset: resetForm,
     formState: { errors, isValid },
   } = useForm<FormValues>({
@@ -62,6 +65,7 @@ export function UploadForm() {
   const acceptFile = useCallback((f: File) => {
     setFile(f);
     setPreview(URL.createObjectURL(f));
+    setHasSuggestedDescription(false);
     setUploadState({ status: "previewing" });
   }, []);
 
@@ -161,6 +165,38 @@ export function UploadForm() {
     }
   };
 
+  const suggestDescription = async () => {
+    if (!file) return;
+
+    setIsSuggestingDescription(true);
+    try {
+      const formData = new FormData();
+      formData.append("image", file);
+
+      const res = await apiFetch("/api/memes/suggest-description", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? "Failed to suggest description");
+      }
+
+      const body = (await res.json()) as SuggestDescriptionResponse;
+      setValue("description", body.description, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+      setHasSuggestedDescription(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to suggest description");
+    } finally {
+      setIsSuggestingDescription(false);
+    }
+  };
+
   // Display success message for SUCCESS_DISPLAY_MS seconds
   // then reset upload form status
   useEffect(() => {
@@ -175,6 +211,7 @@ export function UploadForm() {
     if (preview) URL.revokeObjectURL(preview);
     setFile(null);
     setPreview(null);
+    setHasSuggestedDescription(false);
     resetForm();
     setUploadState({ status: "idle" });
   };
@@ -245,6 +282,28 @@ export function UploadForm() {
               disabled={uploadState.status === "uploading"}
               {...register("description")}
             />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              onClick={suggestDescription}
+              disabled={uploadState.status === "uploading" || isSuggestingDescription || hasSuggestedDescription}
+            >
+              {isSuggestingDescription ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : hasSuggestedDescription ? (
+                <CheckCircle className="mr-2 h-4 w-4 text-green-600 dark:text-green-400" />
+              ) : (
+                <Sparkles className="mr-2 h-4 w-4" />
+              )}
+              Suggest description
+            </Button>
+            {hasSuggestedDescription && (
+              <span id="description-suggested-status" className="sr-only">
+                Description suggested
+              </span>
+            )}
             {errors.description && <p className="mt-1 text-xs text-red-500">{errors.description.message}</p>}
           </div>
 

--- a/src/lib/ai-description.test.ts
+++ b/src/lib/ai-description.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const mockResponsesCreate = vi.fn();
+
+vi.mock("openai", () => ({
+  default: vi.fn(() => ({
+    responses: {
+      create: (...args: unknown[]) => mockResponsesCreate(...args),
+    },
+  })),
+}));
+
+import { suggestMemeDescription } from "./ai-description";
+
+function makeImageFile() {
+  return {
+    type: "image/png",
+    arrayBuffer: async () => new ArrayBuffer(128),
+  } as File;
+}
+
+describe("suggestMemeDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("requests a single sentence description capped at 100 characters", async () => {
+    mockResponsesCreate.mockResolvedValue({
+      output_text: JSON.stringify({ description: "A cat panics while reading a laptop screen." }),
+    });
+
+    const description = await suggestMemeDescription(makeImageFile());
+
+    expect(description).toBe("A cat panics while reading a laptop screen.");
+    expect(mockResponsesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          expect.objectContaining({
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "input_text",
+                text: expect.stringContaining("100 characters or fewer"),
+              }),
+            ]),
+          }),
+        ],
+        text: {
+          format: expect.objectContaining({
+            schema: expect.objectContaining({
+              properties: {
+                description: expect.objectContaining({
+                  maxLength: 100,
+                }),
+              },
+            }),
+          }),
+        },
+      }),
+    );
+  });
+
+  test("rejects descriptions longer than 100 characters", async () => {
+    mockResponsesCreate.mockResolvedValue({
+      output_text: JSON.stringify({
+        description:
+          "A very long meme description that rambles past the allowed one hundred character limit for the upload form.",
+      }),
+    });
+
+    await expect(suggestMemeDescription(makeImageFile())).rejects.toThrow("Invalid AI description response");
+  });
+});

--- a/src/lib/ai-description.ts
+++ b/src/lib/ai-description.ts
@@ -1,0 +1,72 @@
+import OpenAI from "openai";
+import { z } from "zod";
+
+const DEFAULT_MODEL = "gpt-5-nano";
+const MAX_DESCRIPTION_LENGTH = 100;
+
+const suggestionSchema = z.object({
+  description: z.string().trim().min(1).max(MAX_DESCRIPTION_LENGTH),
+});
+
+let openaiClient: OpenAI | null = null;
+
+function getOpenAIClient() {
+  openaiClient ??= new OpenAI();
+  return openaiClient;
+}
+
+export async function suggestMemeDescription(file: File): Promise<string> {
+  const arrayBuffer = await file.arrayBuffer();
+  const base64 = Buffer.from(arrayBuffer).toString("base64");
+  const imageUrl = `data:${file.type};base64,${base64}`;
+
+  const response = await getOpenAIClient().responses.create({
+    model: DEFAULT_MODEL,
+    input: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text:
+              `Describe this meme image in one concise, searchable sentence of ${MAX_DESCRIPTION_LENGTH} characters or fewer. ` +
+              "If image has texts, prioritize concatenating those to the description, " +
+              "then if there are still space, describe visible content, and the meme's likely situation or reaction. " +
+              "Do not identify private people or guess sensitive traits.",
+          },
+          {
+            type: "input_image",
+            image_url: imageUrl,
+            detail: "low",
+          },
+        ],
+      },
+    ],
+    text: {
+      format: {
+        type: "json_schema",
+        name: "meme_description_suggestion",
+        strict: true,
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            description: {
+              type: "string",
+              minLength: 1,
+              maxLength: MAX_DESCRIPTION_LENGTH,
+            },
+          },
+          required: ["description"],
+        },
+      },
+    },
+  });
+
+  const parsed = suggestionSchema.safeParse(JSON.parse(response.output_text));
+  if (!parsed.success) {
+    throw new Error("Invalid AI description response");
+  }
+
+  return parsed.data.description;
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -65,6 +65,7 @@ export type AdminUser = typeof users.$inferSelect;
 export type AdminUsersResponse = { users: AdminUser[] };
 export type AdminUserResponse = { user: AdminUser };
 export type UploadUrlResponse = { uploadUrl: string; key: string; imageUrl: string };
+export type SuggestDescriptionResponse = { description: string };
 export type ErrorResponse = { error: string };
 export type RedirectResponse = { redirect: string };
 


### PR DESCRIPTION
## Summary

Adds an AI-assisted description suggestion flow to the meme upload form. Users can select an image, click **Suggest description**, review or edit the generated text, and then continue through the existing upload flow.

## Changes

### OpenAI SDK and configuration

- Added the official `openai` package.
- Added server-only OpenAI environment variables to `.env.example`:
  - `OPENAI_API_KEY`
- Introduced `src/lib/ai-description.ts` as the single helper responsible for calling OpenAI.

### AI description generation

- Sends the selected image to OpenAI as a base64 data URL from the server side.
- Uses image detail `low` to keep the request cheaper for this metadata use case.
- Requests one concise, searchable English sentence.
- Enforces a single `MAX_DESCRIPTION_LENGTH` constant of `100` characters across the prompt, structured output schema, and runtime validation.
- Uses structured JSON output with a required `description` field.
- Validates the returned description with Zod before returning it to the API route.

### New API route

- Added `POST /api/memes/suggest-description`.
- Requires the existing authenticated user flow.
- Accepts `multipart/form-data` with an `image` file.
- Reuses upload constraints:
  - PNG, JPEG, GIF, or WebP only
  - 2 MB maximum file size
- Returns `{ description }` on success.
- Returns safe API errors for missing file, invalid type, oversized file, invalid form data, and AI failures.

### Upload form UX

- Added a **Suggest description** button below the description textarea.
- Sends the currently selected image to the new API route without changing the existing S3 upload flow.
- Fills the description textarea with the returned suggestion.
- Shows a loading spinner while the suggestion request is in flight.
- Disables the suggestion button after a successful suggestion for the current image to reduce repeated paid API calls.
- Resets that disabled state when the user cancels or selects a new image.
- Shows a green checkmark on the button once suggestion has completed.
- Keeps manual description editing fully available after AI fills the field.
- Shows a toast on suggestion failure and leaves the manual upload flow usable.

### Types and tests

- Added `SuggestDescriptionResponse` to shared API response types.
- Added route tests for auth, missing image, invalid file type, oversized file, success, and AI failure.
- Added OpenAI helper tests for the 100-character prompt/schema contract and over-limit validation.
- Extended upload form tests for suggestion success, failure, disabling after success, re-enabling on new image, and completed status.

## Validation

- `npm test -- src/lib/ai-description.test.ts src/app/api/memes/suggest-description/route.test.ts src/components/upload-form.test.tsx`
  - 3 files passed
  - 32 tests passed
- `npx tsc --noEmit`
  - passed

## Notes

The image is not sent directly from the browser to OpenAI. The browser sends it to the authenticated Next.js API route, and the server calls OpenAI using the server-side API key so the key is never exposed to the client.
